### PR TITLE
Add FastAPI report system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
-# gpt_code
-gpt code
+# Report System with FastAPI
+
+This project provides a simple report system built with **FastAPI** and an HTML frontend. It displays data in a spreadsheet-like table and renders charts directly in the browser.
+
+## Features
+- Interactive table powered by [DataTables](https://datatables.net/) with sorting and filtering
+- Bar chart built with [Chart.js](https://www.chartjs.org/)
+- SQLite database managed via SQLAlchemy
+- Sample data seeded on startup
+
+## Running the App
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Start the server:
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+3. Open a browser and navigate to `http://localhost:8000` to view the report.
+
+## Tests
+Run the unit tests with:
+```bash
+pytest
+```

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,11 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./app.db"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,79 @@
+from datetime import date
+from fastapi import Depends, FastAPI, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from fastapi.staticfiles import StaticFiles
+from sqlalchemy.orm import Session
+from sqlalchemy import func
+
+from . import models
+from .database import SessionLocal, engine
+
+# Create tables
+models.Base.metadata.create_all(bind=engine)
+
+app = FastAPI()
+
+# Mount static files if needed
+app.mount("/static", StaticFiles(directory="static"), name="static")
+
+templates = Jinja2Templates(directory="templates")
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@app.on_event("startup")
+def startup_event():
+    """Seed initial data if database is empty."""
+    db = SessionLocal()
+    try:
+        if db.query(models.Record).count() == 0:
+            sample = [
+                models.Record(category="A", value=10, date=date(2023, 1, 1)),
+                models.Record(category="B", value=15, date=date(2023, 1, 2)),
+                models.Record(category="A", value=7, date=date(2023, 1, 3)),
+                models.Record(category="C", value=20, date=date(2023, 1, 4)),
+            ]
+            db.add_all(sample)
+            db.commit()
+    finally:
+        db.close()
+
+
+@app.get("/", response_class=HTMLResponse)
+async def read_root(request: Request):
+    return templates.TemplateResponse("index.html", {"request": request})
+
+
+@app.get("/records")
+async def read_records(category: str | None = None, db: Session = Depends(get_db)):
+    query = db.query(models.Record)
+    if category:
+        query = query.filter(models.Record.category == category)
+    return [
+        {
+            "id": r.id,
+            "category": r.category,
+            "value": r.value,
+            "date": r.date.isoformat(),
+        }
+        for r in query.all()
+    ]
+
+
+@app.get("/chart-data")
+async def chart_data(db: Session = Depends(get_db)):
+    results = (
+        db.query(models.Record.category, func.sum(models.Record.value))
+        .group_by(models.Record.category)
+        .all()
+    )
+    labels = [r[0] for r in results]
+    values = [r[1] for r in results]
+    return {"labels": labels, "values": values}

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,11 @@
+from sqlalchemy import Column, Integer, String, Float, Date
+from .database import Base
+
+
+class Record(Base):
+    __tablename__ = "records"
+
+    id = Column(Integer, primary_key=True, index=True)
+    category = Column(String, index=True)
+    value = Column(Float)
+    date = Column(Date)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+sqlalchemy
+jinja2
+pytest
+requests

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Report System</title>
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.13.4/css/jquery.dataTables.min.css">
+    <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+    <h1>Records</h1>
+    <table id="records-table" class="display">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Category</th>
+                <th>Value</th>
+                <th>Date</th>
+            </tr>
+        </thead>
+    </table>
+    <h2>Chart</h2>
+    <canvas id="chart" width="400" height="200"></canvas>
+    <script>
+    $(document).ready(function() {
+        var table = $('#records-table').DataTable({
+            ajax: '/records',
+            columns: [
+                {data: 'id'},
+                {data: 'category'},
+                {data: 'value'},
+                {data: 'date'}
+            ]
+        });
+
+        function loadChart(){
+            $.getJSON('/chart-data', function(data){
+                new Chart(document.getElementById('chart'), {
+                    type: 'bar',
+                    data: {
+                        labels: data.labels,
+                        datasets: [{
+                            label: 'Value',
+                            data: data.values
+                        }]
+                    }
+                });
+            });
+        }
+        loadChart();
+    });
+    </script>
+</body>
+</html>

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,21 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+
+def test_read_records():
+    client = TestClient(app)
+    response = client.get('/records')
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) >= 1
+    assert {'id', 'category', 'value', 'date'} <= data[0].keys()
+
+
+def test_chart_data():
+    client = TestClient(app)
+    response = client.get('/chart-data')
+    assert response.status_code == 200
+    data = response.json()
+    assert 'labels' in data and 'values' in data
+    assert len(data['labels']) == len(data['values'])


### PR DESCRIPTION
## Summary
- build basic FastAPI app serving interactive table and chart
- seed SQLite database and expose JSON endpoints for records and chart data
- add tests and documentation

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68ba99cf451c832099a303b345bc24e2